### PR TITLE
Serialize VM creation to prevent starting with wrong network.

### DIFF
--- a/dist/script/models/vmModel.js
+++ b/dist/script/models/vmModel.js
@@ -344,16 +344,21 @@ XenClient.UI.VMModel = function(vm_path) {
         return networks;
     };
 
-    this.addNetwork = function(network_path, wireless, success, failure) {
+    this.addNetwork = function(network_path, wireless, refresh, success, failure) {
         interfaces.vm.add_nic(function(nic_path) {
             var nic = new XenClient.UI.VMNicModel(nic_path);
             nic.load(function() {
                 nic.save({"network_path": network_path, "wireless": wireless}, function() {
-                    self.refreshNics(nic_path, success, failure);
+                    if(refresh) {
+                        self.refreshNics(nic_path, success, failure);
+                    } else {
+                        success();
+                    }
                 }, failure);
             }, failure);
         }, failure);
     };
+
 
     this.refreshNics = function(nic_path, success, failure) {
         function refreshNic(path, finish) {

--- a/widgets/xenclient/AddNic.js
+++ b/widgets/xenclient/AddNic.js
@@ -68,7 +68,7 @@ return declare("citrix.xenclient.AddNic", [dialog, _boundContainerMixin], {
             }
             return false;
         }, this);
-        this.vm.addNetwork(this._network_path, wireless, function() {
+        this.vm.addNetwork(this._network_path, wireless, true, function() {
             XUtils.publish(XenConstants.TopicTypes.UI_HIDE_WAIT);
         }, function(error) {
             XUICache.messageBox.showError(error, XenConstants.ToolstackCodes);

--- a/widgets/xenclient/MediaWizard.js
+++ b/widgets/xenclient/MediaWizard.js
@@ -95,25 +95,61 @@ return declare("citrix.xenclient.MediaWizard", [_wizard], {
 
                 var save = function() {
                     var saveDeferred = new dojo.Deferred();
+
+                    // Keep track of the outstanding asynchronous "tasks" to be completed;
+                    // this ensures we don't autostart a VM until all processing is completed.
+                    var tasksRemaining = 0;
+
+                    // Quick funciton that should run whenever we're finsished
+                    // with a task that may be blocking VM autostart.
+                    var finalizeVM = function() {
+
+                        // If we're not the final task, decrease the task count,
+                        // but don't actually complete the VM's creation, as there
+                        // are outstanding tasks.
+                        if(tasksRemaining > 0) {
+                            tasksRemaining -= 1;
+                            return;
+                        }
+
+                        // If we are the final task, finish up VM completion.
+                        if (result.autoStart != "off") {
+                            vm.start();
+                        }
+                    }
+
                     vm.save(function() {
+
+                        var createWired = (self._hasWired && result.wiredNetwork != "");
+                        var createWireless = (self._hasWireless && result.wirelessNetwork != "");
+
+                        if(result.vmMode == "single") {
+                            XUICache.Host.set_native_vm(vm.vm_path);
+                        }
+
+                        // Count the total number of asynchronous tasks to be completed before we
+                        // start the VM. Note that this section _must_ come before any addNetwork calls,
+                        // to avoid a nasty race.
+                        if(createWired) {
+                          tasksRemaining += 1;
+                        }
+                        if(createWireless) {
+                          tasksRemaining += 1;
+                        }
+
                         // Set wired network
-                        if(self._hasWired && result.wiredNetwork != "") {
-                            vm.addNetwork(result.wiredNetwork, false, function() {}, function(error) {
+                        if(createWired) {
+                            vm.addNetwork(result.wiredNetwork, false, false, finalizeVM, function(error) {
                                 XUICache.messageBox.showError(error, XenConstants.ToolstackCodes);
                             });
                         }
                         // Set wireless network
-                        if(self._hasWireless && result.wirelessNetwork != "") {
-                            vm.addNetwork(result.wirelessNetwork, true, function() {}, function(error) {
+                        if(createWireless) {
+                            vm.addNetwork(result.wirelessNetwork, true, false, finalizeVM, function(error) {
                                 XUICache.messageBox.showError(error, XenConstants.ToolstackCodes);
                             });
                         }
-                        if(result.vmMode == "single") {
-                            XUICache.Host.set_native_vm(vm.vm_path);
-                        }
-                        if (result.autoStart != "off") {
-                            vm.start();
-                        }
+                        finalizeVM();
                         saveDeferred.callback(true);
                     }, saveDeferred.errback);
                     return saveDeferred;


### PR DESCRIPTION
OXT-421

On VM creation, we currently fire off a set of property adjustments
and then (if desired) autostart the VM. Unfortunately, this can result
in the VM starting before all properties are set-- resulting in a VM
that potentially conncets to the wrong network backend.

This commit moves the VM start code to execute after each of the
property adjustments has completed.
